### PR TITLE
Custom Config Sync: Fixed an error in the code of RequestSync function.

### DIFF
--- a/docs/dev/intermediate/custom-config-syncing.md
+++ b/docs/dev/intermediate/custom-config-syncing.md
@@ -28,7 +28,7 @@ Add an **Assembly Reference** to the following files:<br>
 `Unity.Netcode.Runtime.dll`<br>
 `Unity.Collections.dll`
 
-These can be found at `.../Lethal Company/LethalCompany_Data/Managed`.
+These can be found at `.../Lethal Company/Lethal Company_Data/Managed`.
 
 Now create a `SyncedInstance.cs` file which your config will inherit from, this handles the serialization/de-serialization of data.<br>
 It also provides some helper methods to prevent repeating ourselves.


### PR DESCRIPTION
Improved the Custom Config Syncing wiki page for a better reliability for FastBufferWriter size.  
  
Previously, the code was invalid and it gave the wrong FastBufferWriter size for a certain data bytes array size, I don't really know why, but basically now instead of `data.Length` I've put `FastBufferWriter.GetWriteSize(data)` to get a correct size for the FastBufferWriter.